### PR TITLE
Fix link for logrus in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Run `make help` to see the available management commands, or just run `make` to 
 - Works with either in a global `GOPATH` or with a local vendor directory
 - Uses [glide](https://github.com/Masterminds/glide) for dependency management
 - Uses [viper](https://github.com/spf13/viper) for env var config
-- Uses [logrus](https://github.com/spf13/viper) for logging
+- Uses [logrus](https://github.com/sirupsen/logrus) for logging


### PR DESCRIPTION
Fixed the link to logrus in README.md, was pointing to viper.