### PR TITLE
Update Dockerfile to correct build issues

### DIFF
--- a/{{cookiecutter.app_name}}/Dockerfile
+++ b/{{cookiecutter.app_name}}/Dockerfile
@@ -4,7 +4,7 @@ FROM {{cookiecutter.docker_build_image}} AS build-stage
 LABEL app="build-{{cookiecutter.app_name}}"
 LABEL REPO="https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.app_name}}"
 
-ENV GOROOT=/usr/lib/go \
+ENV GOROOT=/usr/local/go \
     GOPATH=/gopath \
     GOBIN=/gopath/bin \
     PROJPATH=/gopath/src/github.com/{{cookiecutter.github_username}}/{{cookiecutter.app_name}}


### PR DESCRIPTION
Running `make package` I ran into an error: 
```
GOPATH=/gopath
go build -ldflags '-w -linkmode external -extldflags "-static" -X main.GitCommit=844219fde13bf43b1d592498393589445618b232 -X main.VersionPrerelease=VersionPrerelease=RC' -o bin/ark-watchman
go: cannot find GOROOT directory: /usr/lib/go
make: *** [Makefile:37: build-alpine] Error 2
```

Running `go env` in the container I found GOROOT to be `/usr/local/go` not `/usr/lib/go`.