### PR TITLE
Add namespace cookiecutter in Dockerfile

### DIFF
--- a/{{cookiecutter.app_name}}/Dockerfile
+++ b/{{cookiecutter.app_name}}/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM {{cookiecutter.docker_build_image}}:{{docker_build_image_version}} AS build-stage
+FROM {{cookiecutter.docker_build_image}}:{{cookiecutter.docker_build_image_version}} AS build-stage
 
 LABEL app="build-{{cookiecutter.app_name}}"
 LABEL REPO="https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.app_name}}"


### PR DESCRIPTION
variable docker_build_image_version in Dockerfile is missing the cookiecutter's namespace, making an error when generating template.
