### PR TITLE
Move Initialize Git method to last

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -102,14 +102,14 @@ else:
     remove_file(".travis.yml")
     remove_circleci_files
 
-# 6. Initialize Git (should be run after all file have been modified or deleted)
-if '{{ cookiecutter.use_git }}'.lower() == 'y':
-    init_git()
-else:
-    remove_file(".gitignore")
-
-# 7. Remove files depending on selection of mod or dep
+# 6. Remove files depending on selection of mod or dep
 if '{{ cookiecutter.go_mod_or_dep}}'.lower() == 'mod':
     remove_file("Gopkg.toml")
 else:
     remove_file("go.mod")
+
+# 7. Initialize Git (should be run after all file have been modified or deleted)
+if '{{ cookiecutter.use_git }}'.lower() == 'y':
+    init_git()
+else:
+    remove_file(".gitignore")


### PR DESCRIPTION
Like the comment you wrote: `Initialize Git (should be run after all file have been modified or deleted)`
but now the mod/dep file is still deleted after git init.

This pull request only switch positions between git init with delete mod/dep method, so git is clean after the project is generated.