### PR TITLE
Use template in import path

### DIFF
--- a/{{cookiecutter.app_name}}/cmd/version.go
+++ b/{{cookiecutter.app_name}}/cmd/version.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/lacion/cookiecutter_golang_example/version"
+	"github.com/{{cookiecutter.github_username}}/{{cookiecutter.app_name}}/version"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
Fixes #30 

## Changelog
- Use template in import in `cmd/version.go`